### PR TITLE
Fixes for modern PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,16 +33,12 @@
     "require": {
         "dirtsimple/clean-yaml": "^0.1",
         "dirtsimple/imposer": "dev-master",
-        "wp-cli/wp-cli": "^2",
-        "wp-cli/entity-command": "^2",
-        "rarst/wpdatetime": "^0.3.0",
+        "wp-cli/wp-cli": "*",
+        "wp-cli/entity-command": "*",
+        "rarst/wpdatetime": "*",
         "league/commonmark": "^1.0",
-        "league/commonmark-ext-smartpunct": "^1.1",
-        "league/commonmark-ext-strikethrough": "^1.0",
-        "league/commonmark-ext-table": "^2.1",
-        "webuni/commonmark-attributes-extension": "^1.0",
-        "twig/twig": "^2.4",
-        "symfony/yaml": "^3.4",
-        "php": "^7.1"
+        "twig/twig": "*",
+        "symfony/yaml": "*",
+        "php": "*"
     }
 }

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -27,10 +27,6 @@ class Formatter {
 				'line_break' => "",
 			),
 			'extensions' => array(
-				#'League\CommonMark\Ext\Table\TableExtension' => null,
-				#'Webuni\CommonMark\AttributesExtension\AttributesExtension' => null,
-				#'League\CommonMark\Ext\Strikethrough\StrikethroughExtension' => null,
-				#'League\CommonMark\Ext\SmartPunct\SmartPunctExtension' => null,
 				'dirtsimple\Postmark\ShortcodeParser' => null,
 			),
 		);

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -28,9 +28,9 @@ class Formatter {
 			),
 			'extensions' => array(
 				'League\CommonMark\Ext\Table\TableExtension' => null,
-				'Webuni\CommonMark\AttributesExtension\AttributesExtension' => null,
-				'League\CommonMark\Ext\Strikethrough\StrikethroughExtension' => null,
-				'League\CommonMark\Ext\SmartPunct\SmartPunctExtension' => null,
+				#'Webuni\CommonMark\AttributesExtension\AttributesExtension' => null,
+				#'League\CommonMark\Ext\Strikethrough\StrikethroughExtension' => null,
+				#'League\CommonMark\Ext\SmartPunct\SmartPunctExtension' => null,
 				'dirtsimple\Postmark\ShortcodeParser' => null,
 			),
 		);

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -27,7 +27,7 @@ class Formatter {
 				'line_break' => "",
 			),
 			'extensions' => array(
-				'League\CommonMark\Ext\Table\TableExtension' => null,
+				#'League\CommonMark\Ext\Table\TableExtension' => null,
 				#'Webuni\CommonMark\AttributesExtension\AttributesExtension' => null,
 				#'League\CommonMark\Ext\Strikethrough\StrikethroughExtension' => null,
 				#'League\CommonMark\Ext\SmartPunct\SmartPunctExtension' => null,

--- a/src/Option.php
+++ b/src/Option.php
@@ -1,7 +1,7 @@
 <?php
 namespace dirtsimple\Postmark;
 
-use WP_CLI\Entity\RecursiveDataStructureTraverser;
+use WP_CLI\Traverser\RecursiveDataStructureTraverser;
 use WP_CLI\Entity\NonExistentKeyException;
 use WP_CLI;
 


### PR DESCRIPTION
How to properly modify `composer.json`?

The problematic dependencies are:
```
composer.json:
"league/commonmark-ext-smartpunct": "^1.1",
"league/commonmark-ext-strikethrough": "^1.0",
"league/commonmark-ext-table": "^2.1",
"webuni/commonmark-attributes-extension": "^1.0",

src/Formatter.php
#'League\CommonMark\Ext\Table\TableExtension' => null,
#'Webuni\CommonMark\AttributesExtension\AttributesExtension' => null,
#'League\CommonMark\Ext\Strikethrough\StrikethroughExtension' => null,
#'League\CommonMark\Ext\SmartPunct\SmartPunctExtension' => null,
```